### PR TITLE
Include `libffi-dev`, required for SNI support

### DIFF
--- a/base_images/base-kobos/Dockerfile
+++ b/base_images/base-kobos/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get -qq update && \
         libxml2-dev \
         libxslt1-dev \
         libjpeg-dev \
+        libffi-dev \
         npm \
         postgresql-client \
         python2.7-dev \


### PR DESCRIPTION
New Python packages need to be installed for the `requests` library to support the SNI configuration used on staging server `mp03`. This development package is a prerequisite of https://github.com/kobotoolbox/dkobo/pull/636.