### PR TITLE
Fix #81, read user/pass from env var not str exp.

### DIFF
--- a/scripts/create_kobo_superuser.bash
+++ b/scripts/create_kobo_superuser.bash
@@ -5,5 +5,6 @@ source /etc/profile
 
 cd /srv/src/kpi
 
-echo "from django.contrib.auth.models import User; print 'UserExists' if User.objects.filter(username='$KOBO_SUPERUSER_USERNAME').count() > 0 else User.objects.create_superuser('$KOBO_SUPERUSER_USERNAME', 'kobo@example.com', '$KOBO_SUPERUSER_PASSWORD');" \
-    | python manage.py shell 2>&1
+# This super long one-liner is to avoid issues with interactive python.
+echo "import os; from django.contrib.auth.models import User; print 'UserExists' if User.objects.filter(username=os.environ['KOBO_SUPERUSER_USERNAME']).count() > 0 else User.objects.create_superuser(os.environ['KOBO_SUPERUSER_USERNAME'], 'kobo@example.com', os.environ['KOBO_SUPERUSER_PASSWORD'])" \
+    | python manage.py shell --plain 2>&1


### PR DESCRIPTION
Using shell expansion to get string values into python code was
running into issues with escaping. Since the shell script used
environmental variables, just read those from within Python.