### PR TITLE
Mount KPI and KC logs to the host filesystem

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -60,6 +60,7 @@ kobocat:
     - ./.vols/static/kobocat:/srv/static
     - ./.vols/kobocat_media_uploads:/srv/src/kobocat/media
     - ./backups/kobocat:/srv/backups
+    - ./log/kobocat:/srv/logs
     - ./scripts/wait_for_rabbit.bash:/etc/my_init.d/01_wait_for_rabbit.bash:ro
     - ./scripts/wait_for_mongo.bash:/etc/my_init.d/02_wait_for_mongo.bash:ro
     - ./scripts/wait_for_postgres.bash:/etc/my_init.d/03_wait_for_postgres.bash:ro
@@ -96,6 +97,7 @@ kpi:
     - ./.vols/static/kpi:/srv/static
     # The Whoosh search index needs persistent storage
     - ./.vols/whoosh:/srv/whoosh
+    - ./log/kpi:/srv/logs
     - ./scripts/wait_for_rabbit.bash:/etc/my_init.d/01_wait_for_rabbit.bash:ro
     - ./scripts/wait_for_mongo.bash:/etc/my_init.d/02_wait_for_mongo.bash:ro
     - ./scripts/wait_for_postgres.bash:/etc/my_init.d/03_wait_for_postgres.bash:ro

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -62,6 +62,7 @@ kobocat:
     - ./.vols/static/kobocat:/srv/static
     - ./.vols/kobocat_media_uploads:/srv/src/kobocat/media
     - ./backups/kobocat:/srv/backups
+    - ./log/kobocat:/srv/logs
     - ./scripts/wait_for_rabbit.bash:/etc/my_init.d/01_wait_for_rabbit.bash:ro
     - ./scripts/wait_for_mongo.bash:/etc/my_init.d/02_wait_for_mongo.bash:ro
     - ./scripts/wait_for_postgres.bash:/etc/my_init.d/03_wait_for_postgres.bash:ro
@@ -106,6 +107,7 @@ kpi:
     - ./.vols/static/kpi:/srv/static
     # The Whoosh search index needs persistent storage
     - ./.vols/whoosh:/srv/whoosh
+    - ./log/kpi:/srv/logs
     - ./scripts/wait_for_rabbit.bash:/etc/my_init.d/01_wait_for_rabbit.bash:ro
     - ./scripts/wait_for_mongo.bash:/etc/my_init.d/02_wait_for_mongo.bash:ro
     - ./scripts/wait_for_postgres.bash:/etc/my_init.d/03_wait_for_postgres.bash:ro

--- a/nginx/nginx_site_https.conf.tmpl
+++ b/nginx/nginx_site_https.conf.tmpl
@@ -34,11 +34,6 @@ server {
     # old Android doesn't support SNI and would never see it there.
     ssl_ciphers 'AES256+EECDH:AES256+EDH:DHE-RSA-AES128-SHA';
 
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-
     # max upload size
     client_max_body_size 75M;
 
@@ -79,11 +74,6 @@ server {
 
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers   'AES256+EECDH:AES256+EDH';
-
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
 
     access_log  /var/log/nginx/kpi.access.log;
     error_log   /var/log/nginx/kpi.error.log;

--- a/nginx/proxy_pass.conf.tmpl
+++ b/nginx/proxy_pass.conf.tmpl
@@ -2,3 +2,7 @@
 # Context: location
 
 proxy_pass http://${container_name}:${container_port};
+proxy_set_header Host $host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;

--- a/nginx/proxy_pass.conf.tmpl
+++ b/nginx/proxy_pass.conf.tmpl
@@ -4,5 +4,5 @@
 proxy_pass http://${container_name}:${container_port};
 proxy_set_header Host $host;
 proxy_set_header X-Real-IP $remote_addr;
-proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-For $remote_addr;
 proxy_set_header X-Forwarded-Proto $scheme;

--- a/nginx/uwsgi_pass.conf.tmpl
+++ b/nginx/uwsgi_pass.conf.tmpl
@@ -4,6 +4,7 @@
 uwsgi_read_timeout 130;
 uwsgi_send_timeout 130;
 uwsgi_pass ${container_name}:${container_port};
+# For setting HTTP headers, see http://stackoverflow.com/a/14133533/1877326.
 uwsgi_param HTTP_X_REAL_IP $remote_addr;
 uwsgi_param HTTP_X_FORWARDED_FOR $remote_addr;
 uwsgi_param HTTP_X_FORWARDED_PROTO $scheme;

--- a/nginx/uwsgi_pass.conf.tmpl
+++ b/nginx/uwsgi_pass.conf.tmpl
@@ -4,4 +4,7 @@
 uwsgi_read_timeout 130;
 uwsgi_send_timeout 130;
 uwsgi_pass ${container_name}:${container_port};
+uwsgi_param HTTP_X_REAL_IP $remote_addr;
+uwsgi_param HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
+uwsgi_param HTTP_X_FORWARDED_PROTO $scheme;
 include /etc/nginx/uwsgi_params;

--- a/nginx/uwsgi_pass.conf.tmpl
+++ b/nginx/uwsgi_pass.conf.tmpl
@@ -5,6 +5,6 @@ uwsgi_read_timeout 130;
 uwsgi_send_timeout 130;
 uwsgi_pass ${container_name}:${container_port};
 uwsgi_param HTTP_X_REAL_IP $remote_addr;
-uwsgi_param HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
+uwsgi_param HTTP_X_FORWARDED_FOR $remote_addr;
 uwsgi_param HTTP_X_FORWARDED_PROTO $scheme;
 include /etc/nginx/uwsgi_params;


### PR DESCRIPTION
After #115.
kobotoolbox/kobocat#366 required first.