### PR TITLE
Include `$proxy_port` in the Host header

### DIFF
--- a/nginx/proxy_pass.conf.tmpl
+++ b/nginx/proxy_pass.conf.tmpl
@@ -2,7 +2,7 @@
 # Context: location
 
 proxy_pass http://${container_name}:${container_port};
-proxy_set_header Host $host;
+proxy_set_header Host $host:$proxy_port;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $remote_addr;
 proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
when `proxy_pass`ing to `runserver_plus` since [Django expects that](https://github.com/django/django/blob/1.8.18/django/http/request.py#L79).

Fixes #119.