### PR TITLE
OCHA uWSGI-related changes

### DIFF
--- a/docker-compose.frontend.server.yml
+++ b/docker-compose.frontend.server.yml
@@ -17,7 +17,8 @@ services:
       - ENKETO_PROTOCOL=https
       - KPI_PORT=8000
       - KC_UWSGI_MAX_REQUESTS=2048
-      - KC_UWSGI_WORKERS_COUNT=4
+      - KC_UWSGI_WORKERS_COUNT=24
+      - KC_UWSGI_CHEAPER_RSS_LIMIT_SOFT=7516192768
       - KC_UWSGI_CHEAPER_WORKERS_COUNT=2
     links:
       - kpi
@@ -49,7 +50,8 @@ services:
       - SECURE_PROXY_SSL_HEADER=HTTP_X_FORWARDED_PROTO, https
       - SYNC_KOBOCAT_XFORMS=False # Should be True on at least one frontend environment
       - KPI_UWSGI_MAX_REQUESTS=2048
-      - KPI_UWSGI_WORKERS_COUNT=4
+      - KPI_UWSGI_WORKERS_COUNT=24
+      - KC_UWSGI_CHEAPER_RSS_LIMIT_SOFT=7516192768
       - KPI_UWSGI_CHEAPER_WORKERS_COUNT=2
     volumes:
       - ./.vols/static/kpi:/srv/static

--- a/uwsgi/kc_uwsgi.ini
+++ b/uwsgi/kc_uwsgi.ini
@@ -6,7 +6,14 @@ module          = onadata.apps.main.wsgi
 logto           = $(KOBOCAT_LOGS_DIR)/uwsgi.log
 
 # process related settings
-master          = true
+master              = true
+harakiri            = 120
+worker-reload-mercy = 120
+
+# monitoring (use with `uwsgitop :1717`, for example)
+stats = :1717
+memory-report = true
+
 # Overrideable default of 2 uWSGI processes.
 if-env = KC_UWSGI_WORKERS_COUNT
 workers = %(_)
@@ -21,6 +28,15 @@ cheaper-algo = spare
 cheaper = %(_)
 cheaper-initial = %(_)
 cheaper-step = 1
+cheaper-overload = 1
+endif =
+
+# stop spawning new workers if total memory consumption grows too large
+if-env = KC_UWSGI_CHEAPER_RSS_LIMIT_SOFT
+cheaper-rss-limit-soft = %(_)
+endif =
+if-not-env = KC_UWSGI_CHEAPER_RSS_LIMIT_SOFT
+cheaper-rss-limit-soft = %(2 * 1024 * 1024 * 1024)
 endif =
 
 # respawn processes after serving KC_UWSGI_MAX_REQUESTS requests (default 5000)
@@ -28,9 +44,16 @@ if-env = KC_UWSGI_MAX_REQUESTS
 max-requests = %(_)
 endif =
 
+# respawn individual workers when their memory consumption grows too large
+if-env = KC_UWSGI_RELOAD_ON_RSS_MB
+reload-on-rss = %(_)
+endif =
+if-not-env = KC_UWSGI_RELOAD_ON_RSS_MB
+reload-on-rss = 512
+endif =
+
 socket          = 0.0.0.0:8000
 buffer-size     = 32768
-harakiri        = 120
 
 uid             = $(UWSGI_USER)
 gid             = $(UWSGI_GROUP)

--- a/uwsgi/kpi_uwsgi.ini
+++ b/uwsgi/kpi_uwsgi.ini
@@ -12,7 +12,13 @@ mount              = $(KPI_PREFIX)=$(KPI_SRC_DIR)/kobo/wsgi.py
 
 
 # process related settings
-master = true
+master              = true
+harakiri            = 120
+worker-reload-mercy = 120
+
+# monitoring (use with `uwsgitop :1717`, for example)
+stats = :1717
+memory-report = true
 
 # Overrideable default of 2 uWSGI processes.
 if-env = KPI_UWSGI_WORKERS_COUNT
@@ -28,14 +34,29 @@ cheaper-algo = spare
 cheaper = %(_)
 cheaper-initial = %(_)
 cheaper-step = 1
+cheaper-overload = 1
 endif =
 
+# stop spawning new workers if total memory consumption grows too large
+if-env = KPI_UWSGI_CHEAPER_RSS_LIMIT_SOFT
+cheaper-rss-limit-soft = %(_)
+endif =
+if-not-env = KPI_UWSGI_CHEAPER_RSS_LIMIT_SOFT
+cheaper-rss-limit-soft = %(2 * 1024 * 1024 * 1024)
+endif =
 
 # respawn processes after serving KPI_UWSGI_MAX_REQUESTS requests (default 5000)
 if-env = KPI_UWSGI_MAX_REQUESTS
 max-requests = %(_)
 endif =
 
+# respawn workers when their memory consumption grows too large
+if-env = KPI_UWSGI_RELOAD_ON_RSS_MB
+reload-on-rss = %(_)
+endif =
+if-not-env = KPI_UWSGI_RELOAD_ON_RSS_MB
+reload-on-rss = 512
+endif =
 
 socket          = 0.0.0.0:8000
 buffer-size     = 32768
@@ -46,3 +67,6 @@ die-on-term     = true
 
 # uWSGI does not pass locale information to the application by default
 env = LC_ALL=en_US.UTF-8
+
+# Required for Raven/Sentry
+enable-threads  = true


### PR DESCRIPTION
* Spawn up to 24 workers for each app (as long as RSS stays below 7G)
* Reload individual workers if their RSS exceeds 512M
* Set `cheaper-overload = 1` to add workers right away if all existing are busy
* Enable `harakiri` and threading on KPI to match KC