### PR TITLE
Update README.MD for initial setup (Bugfix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Once this is noted, you can `docker-compose stop` and search for potentially-mis
 
 11. Start the server: `docker-compose up -d` (or without the `-d` option to run in the foreground).
 
+11 - Bugfix. # FORM DEPLOYMENT BUG PLEASE BE ADVICED - AS FROM 10/04/2018: (should be removed when fixed)
+If you start the kobo-docker framework the first time you have to set the permission of the media-folder correctly.
+otherwise form deployment as well as project creation will fail:
+Please run the following command inside your kobo-docker folder:
+`docker-compose exec kobocat chown -R wsgi /srv/src/kobocat`
+
 12. Container output can be followed with `docker-compose logs -f`. For an individual container, logs can be followed by using the container name from your `docker-compose.yml` with e.g. `docker-compose logs -f enketo_express`.
 
 "Local" setup users can now reach KoBo Toolbox at `http://${HOST_ADDRESS}:${KPI_PUBLIC_PORT}` (substituting in the values entered in [`envfile.local.txt`](./envfile.local.txt)), while "server" setups can be reached at `https://${KOBOFORM_PUBLIC_SUBDOMAIN}.${PUBLIC_DOMAIN_NAME}` (similarly substituting from [`envfile.server.txt`](./envfile.server.txt)). Be sure to periodically update your containers, especially `nginx`, for security updates by pulling new changes from this `kobo-docker` repo then running e.g. `docker-compose pull && docker-compose up -d`.


### PR DESCRIPTION
As kobo wont run out of the box anymore without setting proper permissions to media folders I suggest adding this information to the INITIAL setup part of the README.MD until it has been resolved, as many people will have to go through the issues list to address this.