### PR TITLE
Provide information about kobocat and enketo url env vars

### DIFF
--- a/envfiles/kobocat.txt
+++ b/envfiles/kobocat.txt
@@ -12,6 +12,10 @@ KOBO_POSTGRES_DB_NAME=kobotoolbox
 KOBO_POSTGRES_USER=kobo
 KOBOCAT_BROKER_URL=amqp://kobocat:kobocat@rabbit:5672/kobocat
 
+# Set the variables below to your kobocat and enketo url
+#KOBOCAT_URL=
+#ENKETO_URL=
+
 #KOBOCAT_UWSGI_PROCESS_COUNT=2
 #ENKETO_OFFLINE_SURVEYS=True
 #KOBOCAT_MONGO_HOST=mongo

--- a/envfiles/kpi.txt
+++ b/envfiles/kpi.txt
@@ -6,6 +6,10 @@ KPI_PREFIX=/
 KPI_BROKER_URL=amqp://kpi:kpi@rabbit:5672/kpi
 DATABASE_URL=postgres://kobo:kobo@postgres:5432/kobotoolbox
 
+# Set the variables below to your kobocat and enketo url
+#KOBOCAT_URL=
+#ENKETO_URL=
+
 DJANGO_LANGUAGE_CODES=en fr es ar zh-hans hi ku
 #DKOBO_PREFIX=False
 #KPI_WHOOSH_DIR=./whoosh_index


### PR DESCRIPTION
These two variables that are responsible for setting proper url addresses to the kobocat and enketo services were not mentioned anywhere in the README or in the files. Without setting them, some of the functionalities were not working correctly.

An example of this is displaying submission attachments (in our case, images) in enketo, which can take place while you edit the submission - images were pointing to non-existing addresses that were based on kc.kobotoolbox.org, instead of using the url address of kobocat brought up by docker.