### PR TITLE
Added new volume to enketo-express to persist files on disk

### DIFF
--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -127,6 +127,7 @@ services:
       # Override Enketo Express icons.
       - ./enketo_express/favicon.ico:/srv/src/enketo_express/public/images/favicon.ico:ro
       - ./enketo_express/icon_180x180.png:/srv/src/enketo_express/public/images/icon_180x180.png:ro
+      - ./.vols/enketo_express:/srv/src/enketo_express/checksum
     networks:
       kobo-fe-network:
         aliases:


### PR DESCRIPTION
Allow to keep checksum version even if the container is removed
To be efficient, `encryption key` should be filled up in `enketo_express` env file.
```
{
    "app name": "Enketo Express for KoBo Toolbox",
    "linked form and data server": {
        "name": "KoBo Toolbox",
        "server url": "",
        "encryption key": "xxxxxxxxxxxxxxxxxxxx"
    },
    ...
}
```

Otherwise a new key is regenerate each time and checks differ. 
Related to https://github.com/enketo/enketo-express/pull/91