### PR TITLE
Postgres lower default values

### DIFF
--- a/postgres/master/postgres.conf
+++ b/postgres/master/postgres.conf
@@ -10,20 +10,20 @@
 # DB Version: 9.5
 # OS Type: linux
 # DB Type: Mixed
-# Hard-drive: SSD
-# Total Memory (RAM): 8GB
+# Hard-drive: HDD
+# Total Memory (RAM): 2GB
 
 # Memory Configuration
-shared_buffers = 2GB
-effective_cache_size = 6GB
-work_mem = 41MB
-maintenance_work_mem = 512MB
+shared_buffers = 512MB
+effective_cache_size = 2GB
+work_mem = 10MB
+maintenance_work_mem = 128MB
 
 # Checkpoint Related Configuration
 min_wal_size = 512MB
 max_wal_size = 2GB
 checkpoint_completion_target = 0.9
-wal_buffers = 16MB
+wal_buffers = 15MB
 
 # Network Related Configuration
 listen_addresses = '*'

--- a/postgres/slave/postgres.conf
+++ b/postgres/slave/postgres.conf
@@ -10,20 +10,20 @@
 # DB Version: 9.5
 # OS Type: linux
 # DB Type: Mixed
-# Hard-drive: SSD
-# Total Memory (RAM): 8GB
+# Hard-drive: HDD
+# Total Memory (RAM): 2GB
 
 # Memory Configuration
-shared_buffers = 2GB
-effective_cache_size = 6GB
-work_mem = 41MB
-maintenance_work_mem = 512MB
+shared_buffers = 512MB
+effective_cache_size = 2GB
+work_mem = 10MB
+maintenance_work_mem = 128MB
 
 # Checkpoint Related Configuration. Must be identical to master settings.
 min_wal_size = 512MB
 max_wal_size = 2GB
 checkpoint_completion_target = 0.9
-wal_buffers = 16MB
+wal_buffers = 15MB
 
 # Network Related Configuration.
 listen_addresses = '*'

--- a/postgres/toggle-backup-activation.sh
+++ b/postgres/toggle-backup-activation.sh
@@ -67,7 +67,7 @@ else
         apt-get install -y python-virtualenv --quiet=2 > /dev/null
         virtualenv /tmp/backup-virtualenv
         . /tmp/backup-virtualenv/bin/activate
-        pip install --quiet humanize smart-open
+        pip install --quiet humanize smart-open==1.7.1
         deactivate
 
         INTERPRETER=/tmp/backup-virtualenv/bin/python


### PR DESCRIPTION
According to https://www.pgconfig.org/#/tuning, 
Default settings postgres have been lower to fit 2GB of RAM. 

`smart-open` pip dependency has been frozen to ver: `1.7.1`. Newer version fails to build and backup to S3 can't run.