### PR TITLE
Accept a double-encoded S3 URL from KoBoCAT

### DIFF
--- a/nginx/nginx_site_default.conf.tmpl
+++ b/nginx/nginx_site_default.conf.tmpl
@@ -55,25 +55,35 @@ server {
         alias /media/;
     }
 
-    location ~ ^/protected-s3/(.*?)/(.*) {
+    location ~ ^/protected-s3/(.*)$ {
+        # Allow internal requests only, i.e. return a 404 to any client who
+        # tries to access this location directly
         internal;
-        set $aws_access_key   'AWSAccessKeyId=$arg_AWSAccessKeyId';
-        set $url_expires      'Expires=$arg_Expires';
-        set $url_signature    'Signature=$arg_Signature';
-        set $bucket_domain_name '$1.s3.amazonaws.com';
-        set $args_full        'https://$bucket_domain_name/$2?$aws_access_key&$url_expires&$url_signature';
-        proxy_set_header       Host $bucket_domain_name;
-        proxy_http_version     1.1;
-        proxy_set_header       Authorization '';
-        proxy_hide_header      x-amz-id-2;
-        proxy_hide_header      x-amz-request-id;
-        proxy_hide_header      Set-Cookie;
-        proxy_ignore_headers   "Set-Cookie";
-        proxy_buffering        off;
-        proxy_intercept_errors off;
-        resolver               8.8.8.8 valid=300s;
-        resolver_timeout       10s;
-        proxy_pass             $args_full;
+        # Name resolution won't work at all without specifying a resolver here.
+        # Configuring a validity period is useful for overriding Amazon's very
+        # short (5-second?) TTLs.
+        resolver 8.8.8.8 8.8.4.4 valid=300s;
+        resolver_timeout 10s;
+        # Everything that S3 needs is in the URL; don't pass any headers or
+        # body content that the client may have sent
+        proxy_pass_request_body off;
+        proxy_pass_request_headers off;
+
+        # Stream the response to the client instead of trying to read it all at
+        # once, which would potentially use disk space
+        proxy_buffering off;
+
+        # Don't leak S3 headers to the client. List retrieved from:
+        # https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html
+        proxy_hide_header x-amz-delete-marker;
+        proxy_hide_header x-amz-id-2;
+        proxy_hide_header x-amz-request-id;
+        proxy_hide_header x-amz-version-id;
+
+        # S3 will complain if `$1` contains non-encoded special characters.
+        # KoBoCAT must encode twice to make sure `$1` is still encoded after
+        # NGINX's automatic URL decoding.
+        proxy_pass $1;
     }
 }
 


### PR DESCRIPTION
Fixes #234
Requires https://github.com/kobotoolbox/kobocat/pull/548