### PR TITLE
Include username in NGINX log for every request

### DIFF
--- a/nginx/logs_with_host.conf
+++ b/nginx/logs_with_host.conf
@@ -1,3 +1,3 @@
-log_format with_host '$http_host | $remote_addr - $remote_user [$time_local] '
+log_format with_host '$http_host | $remote_addr - $upstream_http_x_kobonaut [$time_local] '
                      '"$request" $status ($body_bytes_sent bytes) "$http_referer" '
                      '"$http_user_agent"';


### PR DESCRIPTION
Depends on kobotoolbox/kpi#2300, kobotoolbox/kobocat#559
Closes #245 

**Weakness**: this doesn't affect logging at the load-balancer level, so it will remain difficult to match up  requests that go through a temporary instance with their corresponding users.