### PR TITLE
Force X_FORWARDED_HOST when dev mode is enabled

### DIFF
--- a/nginx/nginx_command.bash
+++ b/nginx/nginx_command.bash
@@ -59,9 +59,15 @@ for container_name in "${!container_ports[@]}"; do
     if [[ "${web_server^^}" != 'UWSGI' ]] ; then
         echo "Proxying directly (debug) to \`${container_name}\` without uWSGI."
 
+        if [ "${container_name}" == "kpi" ]; then
+            export container_x_forwarded_host="${KOBOFORM_PUBLIC_SUBDOMAIN}.${PUBLIC_DOMAIN_NAME}"
+        else
+            export container_x_forwarded_host="${KOBOCAT_PUBLIC_SUBDOMAIN}.${PUBLIC_DOMAIN_NAME}"
+        fi
+
         # Create a `proxy_pass` configuration for this container.
         cat ${ORIGINAL_DIR}/proxy_pass.conf.tmpl \
-            | envsubst '${container_name} ${container_port} ${container_public_port}' \
+            | envsubst '${container_name} ${container_port} ${container_public_port} ${container_x_forwarded_host}' \
             > ${TEMPLATES_ENABLED_DIR}/${container_name}_proxy_pass.conf
 
         # Prepare to include the generated `proxy_pass` config. and no `uwsgi_pass` config.

--- a/nginx/proxy_pass.conf.tmpl
+++ b/nginx/proxy_pass.conf.tmpl
@@ -6,5 +6,5 @@ proxy_set_header Host $host:$proxy_port;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $remote_addr;
 proxy_set_header X-Forwarded-Proto $scheme;
-proxy_set_header X-Forwarded-Host $host$container_public_port;
+proxy_set_header X-Forwarded-Host ${container_x_forwarded_host}${container_public_port};
 proxy_redirect off;


### PR DESCRIPTION
When dev mode is enabled: DJANGO reads `X_FORWARDED_HOST` to return correct `$host`. 
But when `kpi` is corresponding with `kc` internally, the $host is wrong (i.e. returns domain name on internal network) with custom port if exists.

The hyperlinks in serializers in `kc` are build on top of this value and sent to `kpi`. `kpi` uses those value for subsequents calls but fails. 