### PR TITLE
Update dockerize and pip

### DIFF
--- a/base_images/base-kobos/Dockerfile
+++ b/base_images/base-kobos/Dockerfile
@@ -22,11 +22,11 @@ RUN apt-get -qq update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     curl -s https://bootstrap.pypa.io/get-pip.py | python && \
-    # FIXME: Temporarily install `pip` < v8.1.2 until `pip-tools` is compatible.
-    pip install --upgrade pip==8.1.1 && \
     pip install uwsgi && \
     useradd -s /bin/false -m wsgi
 
 # Install Dockerize.
-RUN wget https://github.com/jwilder/dockerize/releases/download/v0.2.0/dockerize-linux-amd64-v0.2.0.tar.gz -P /tmp
-RUN tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64-v0.2.0.tar.gz
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz -P /tmp \
+    && tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm /tmp/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz

--- a/scripts/wait_for_kpi.bash
+++ b/scripts/wait_for_kpi.bash
@@ -2,7 +2,7 @@
 set -e
 
 echo 'Waiting for container `kpi`.'
-dockerize -timeout=60s -wait tcp://kpi:${KPI_PORT}
+dockerize -timeout=300s -wait tcp://kpi:${KPI_PORT}
 echo 'Container `kpi` up.'
 
 echo 'Waiting for `kpi` web service.'


### PR DESCRIPTION
- `dockerize`: updated to version 0.6.1
- `pip`: don't force install of version 8 (as versions are controlled in `kobocat` and `kpi` build).

Closes #94 