### PR TITLE
Pass signals and give grace period to database servers

### DIFF
--- a/docker-compose.backend.template.yml
+++ b/docker-compose.backend.template.yml
@@ -16,6 +16,7 @@ services:
       - ./postgres:/kobo-docker-scripts
     command: "/bin/bash /kobo-docker-scripts/entrypoint.sh"
     restart: on-failure
+    stop_grace_period: 5m
     # Ports should be declared in `docker-compose.backend.master.override.yml` and docker-compose.backend.slave.override.yml`
     #ports:
     #  - 5432:5432
@@ -36,6 +37,7 @@ services:
       - ./log/mongo:/srv/logs
     restart: on-failure
     command: "/bin/bash /kobo-docker-scripts/entrypoint.sh"
+    stop_grace_period: 5m
     # Ports should be declared in `docker-compose.backend.master.override.yml` and docker-compose.backend.slave.override.yml`
     #ports:
     #  - 27017:27017
@@ -56,6 +58,7 @@ services:
       - ./redis/entrypoint.sh:/tmp/redis/entrypoint.sh:ro
       - ./log/redis_main:/var/log/redis
     restart: on-failure
+    stop_grace_period: 2m30s
     # Ports should be declared in `docker-compose.backend.master.override.yml` and docker-compose.backend.slave.override.yml`
     #ports:
     #  - 6379:6379
@@ -73,6 +76,7 @@ services:
       - ./redis/entrypoint.sh:/tmp/redis/entrypoint.sh:ro
       - ./log/redis_cache:/var/log/redis
     restart: on-failure
+    stop_grace_period: 2m30s
     # Ports should be declared in `docker-compose.backend.master.override.yml` and docker-compose.backend.slave.override.yml`
     #ports:
     #  - 6380:6380

--- a/mongo/entrypoint.sh
+++ b/mongo/entrypoint.sh
@@ -10,4 +10,6 @@ echo "Copying init scripts ..."
 cp $KOBO_DOCKER_SCRIPTS_DIR/init_* /docker-entrypoint-initdb.d/
 
 echo "Launching official entrypoint..."
-$BASH_PATH /entrypoint.sh mongod
+# `exec` here is important to pass signals to the database server process;
+# without `exec`, the server will be terminated abruptly with SIGKILL (see #276)
+exec $BASH_PATH /entrypoint.sh mongod

--- a/postgres/entrypoint.sh
+++ b/postgres/entrypoint.sh
@@ -47,4 +47,6 @@ BASH_PATH=$(which bash)
 $BASH_PATH $KOBO_DOCKER_SCRIPTS_DIR/toggle-backup-activation.sh
 
 echo "Launching official entrypoint..."
-/bin/bash /docker-entrypoint.sh postgres
+# `exec` here is important to pass signals to the database server process;
+# without `exec`, the server will be terminated abruptly with SIGKILL (see #276)
+exec /bin/bash /docker-entrypoint.sh postgres

--- a/redis/entrypoint.sh
+++ b/redis/entrypoint.sh
@@ -35,6 +35,6 @@ if [ "${KOBO_REDIS_SERVER_ROLE}" == "main" ]; then
 fi
 
 # `exec` and `gosu` (vs. `su`) here are important to pass signals to the
-# database server process, without them, the server will be terminated abruptly
+# database server process; without them, the server will be terminated abruptly
 # with SIGKILL (see #276)
 exec gosu redis redis-server /etc/redis/redis.conf

--- a/redis/entrypoint.sh
+++ b/redis/entrypoint.sh
@@ -34,4 +34,7 @@ if [ "${KOBO_REDIS_SERVER_ROLE}" == "main" ]; then
     $BASH_PATH $KOBO_DOCKER_SCRIPTS_DIR/toggle-backup-activation.sh
 fi
 
-su redis -c "redis-server /etc/redis/redis.conf"
+# `exec` and `gosu` (vs. `su`) here are important to pass signals to the
+# database server process, without them, the server will be terminated abruptly
+# with SIGKILL (see #276)
+exec gosu redis redis-server /etc/redis/redis.conf


### PR DESCRIPTION
…when stopping Docker containers. Fixes #276.

### Before
<pre><font color="#C4A000">kobo-docker_redis_main_1 exited with code 137</font>
<font color="#75507B">kobo-docker_redis_cache_1 exited with code 137</font>
<font color="#06989A">kobo-docker_mongo_1 exited with code 137</font>
<font color="#4E9A06">kobo-docker_postgres_1 exited with code 137</font>
</pre>

### After
<pre><font color="#C4A000">kobo-docker_redis_main_1 exited with code 0</font>
<font color="#4E9A06">kobo-docker_redis_cache_1 exited with code 0</font>
<font color="#06989A">kobo-docker_mongo_1 exited with code 0</font>
<font color="#75507B">kobo-docker_postgres_1 exited with code 0</font>
</pre>