### PR TITLE
network name frontend yaml

### DIFF
--- a/docker-compose.frontend.override.yml.sample
+++ b/docker-compose.frontend.override.yml.sample
@@ -64,4 +64,4 @@ networks:
     external:
       # name: <prefix>_kobo-be-network`, where `prefix` is usually the parent
       # folder name
-      name: kobodocker_kobo-be-network
+      name: kobo-docker_kobo-be-network


### PR DESCRIPTION
kobo-docker_kobo-be-network must have been the network name.