### PR TITLE
PR #289 fix

### DIFF
--- a/uwsgi/kc_uwsgi.ini
+++ b/uwsgi/kc_uwsgi.ini
@@ -7,8 +7,8 @@ logto           = $(KOBOCAT_LOGS_DIR)/uwsgi.log
 
 # process related settings
 master              = true
-harakiri            = KC_UWSGI_HARAKIRI
-worker-reload-mercy = KC_UWSGI_WORKER_RELOAD_MERCY
+harakiri            = $(KC_UWSGI_HARAKIRI)
+worker-reload-mercy = $(KC_UWSGI_WORKER_RELOAD_MERCY)
 
 # monitoring (use with `uwsgitop :1717`, for example)
 stats = :1717

--- a/uwsgi/kpi_uwsgi.ini
+++ b/uwsgi/kpi_uwsgi.ini
@@ -13,8 +13,8 @@ mount              = $(KPI_PREFIX)=$(KPI_SRC_DIR)/kobo/wsgi.py
 
 # process related settings
 master              = true
-harakiri            = KPI_UWSGI_HARAKIRI
-worker-reload-mercy = KPI_UWSGI_WORKER_RELOAD_MERCY
+harakiri            = $(KPI_UWSGI_HARAKIRI)
+worker-reload-mercy = $(KPI_UWSGI_WORKER_RELOAD_MERCY)
 
 # monitoring (use with `uwsgitop :1717`, for example)
 stats = :1717


### PR DESCRIPTION
I forgot to wrap environment variables in `$(..)` 
```
harakiri            = KPI_UWSGI_HARAKIRI
worker-reload-mercy = KPI_UWSGI_WORKER_RELOAD_MERCY
```
and 
```
harakiri            = KC_UWSGI_HARAKIRI
worker-reload-mercy = KC_UWSGI_WORKER_RELOAD_MERCY
```

In my tests (`KPI_UWSGI_HARAKIRI = 15`and  `import time; time.sleep(20)`), I thought it was working as excepted because of the logs. I was wrong, Haraki was not called here.

```
Tue Jun  9 21:11:04 2020 - worker 2 (pid: 144) is taking too much time to die...NO MERCY !!!
Tue Jun  9 21:11:05 2020 - worker 2 (pid: 144) is taking too much time to die...NO MERCY !!!
```

With correctly wrapped variables $(...),I get correct behaviour.
```
Tue Jun  9 21:15:17 2020 - *** HARAKIRI ON WORKER 1 (pid: 163, try: 1) ***
Tue Jun  9 21:15:17 2020 - HARAKIRI !!! worker 1 status !!!
Tue Jun  9 21:15:17 2020 - HARAKIRI [core 0] 172.16.52.1 - GET /api/v2/assets.json since 1591737301
Tue Jun  9 21:15:17 2020 - HARAKIRI !!! end of worker 1 status !!!
```