### PR TITLE
Restore `ENKETO_API_TOKEN` for now

### DIFF
--- a/env/envfile.txt
+++ b/env/envfile.txt
@@ -15,15 +15,24 @@ KOBOFORM_PUBLIC_SUBDOMAIN=kobo
 KOBOCAT_PUBLIC_SUBDOMAIN=kc
 # The publicly-accessible subdomain for the Enketo Express web forms (e.g. enketo).
 ENKETO_EXPRESS_PUBLIC_SUBDOMAIN=ee
-# See "api key" here: https://github.com/kobotoolbox/enketo-express/tree/master/config#linked-form-and-data-server.
+
+# For now, you must set ENKETO_API_TOKEN, used by KPI and KoBoCAT, to the same
+# value as ENKETO_API_KEY. Eventually, KPI and KoBoCAT will also read
+# ENKETO_API_KEY and the duplication will no longer be necessary.
+# For a description of this setting, see "api key" here:
+# https://github.com/kobotoolbox/enketo-express/tree/master/config#linked-form-and-data-server.
 ENKETO_API_KEY=
+ENKETO_API_TOKEN=
+
 # Canonically a 50-character random string. For Django 1.8.13, see https://docs.djangoproject.com/en/1.8/ref/settings/#secret-key and https://github.com/django/django/blob/4022b2c306e88a4ab7f80507e736ce7ac7d01186/django/core/management/commands/startproject.py#L29-L31.
 # To generate a secret key in the same way as `django-admin startproject` you can run:
 # docker-compose run --rm kpi python -c 'from django.utils.crypto import get_random_string; print(get_random_string(50, "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)"))'
 DJANGO_SECRET_KEY=
+
 # The initial superuser's username.
 KOBO_SUPERUSER_USERNAME=
 # The initial superuser's password.
 KOBO_SUPERUSER_PASSWORD=
+
 # The e-mail address where your users can contact you.
 KOBO_SUPPORT_EMAIL=support@domain.name


### PR DESCRIPTION
since it's still used by KPI and KoBoCAT