### PR TITLE
Modification of the WALE_S3_PREFIX variable

### DIFF
--- a/postgres/toggle-backup-activation.sh
+++ b/postgres/toggle-backup-activation.sh
@@ -79,7 +79,7 @@ else
             mkdir -p ${POSTGRES_DATA_DIR}/wal-e.d/env
             echo "${AWS_SECRET_ACCESS_KEY}" > ${POSTGRES_DATA_DIR}/wal-e.d/env/AWS_SECRET_ACCESS_KEY
             echo "${AWS_ACCESS_KEY_ID}" > ${POSTGRES_DATA_DIR}/wal-e.d/env/AWS_ACCESS_KEY_ID
-            echo "${BACKUP_AWS_STORAGE_BUCKET_NAME}" > ${POSTGRES_DATA_DIR}/wal-e.d/env/WALE_S3_PREFIX
+            echo "s3://${BACKUP_AWS_STORAGE_BUCKET_NAME}/postgres/" > ${POSTGRES_DATA_DIR}/wal-e.d/env/WALE_S3_PREFIX
             echo "${EC2_REGION}" > ${POSTGRES_DATA_DIR}/wal-e.d/env/AWS_REGION
             chown -R postgres:postgres ${POSTGRES_DATA_DIR}/wal-e.d
 


### PR DESCRIPTION
Error sending WAL Postgres files to S3 :
```
wal_e.main   ERROR    MSG: bad S3, Windows Azure Blob Storage, OpenStack Swift, Google Cloud Storage or File URL scheme passed
        DETAIL: The scheme  was passed when "s3", "wabs", "swift", "gs", or "file" was expected.
        STRUCTURED: time=2020-11-06T09:40:43.933816-00 pid=1202
[2020-11-06 09:40:43 UTC] LOG:  archive command failed with exit code 1
[2020-11-06 09:40:43 UTC] DETAIL:  The failed archive command was: envdir /var/lib/postgresql/data/wal-e.d/env wal-e wal-push pg_xlog/000000010000000000000001
[2020-11-06 09:40:43 UTC] WARNING:  archiving transaction log file "000000010000000000000001" failed too many times, will try again later
```

The WALE_S3_PREFIX variable must be : ```s3://[BUCKET_NAME]/postgres/``` instead of just ```[BUCKET_NAME]```.
