### PR TITLE
Serve public KPI media via NGINX

### DIFF
--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -98,6 +98,7 @@ services:
         - ./.vols/static:/srv/www:ro
         - ./log/nginx:/var/log/nginx
         - ./.vols/kobocat_media_uploads:/media
+        - ./.vols/kpi_media/__public:/srv/kpi_media/__public:ro
         - ./nginx/docker-entrypoint.d/30-init-kobo-nginx.sh:/docker-entrypoint.d/30-init-kobo-nginx.sh
         - ./nginx/kobo-docker-scripts/:/kobo-docker-scripts
     restart: always

--- a/nginx/kobo-docker-scripts/templates/nginx_site_default.conf.tmpl
+++ b/nginx/kobo-docker-scripts/templates/nginx_site_default.conf.tmpl
@@ -107,6 +107,11 @@ server {
         alias /srv/www/kpi;
     }
 
+    # public media, e.g. custom logos (KPI `ConfigurationFile`s)
+    location /media/__public {
+        alias /srv/kpi_media/__public;
+    }
+
     error_page 418 = /static/html/Offline.html;
 
     location / {


### PR DESCRIPTION
## Description

Allow customization of login background and logos when using local (non-S3) storage, by serving those images in a publicly-accessible location

## Related issues

Fixes #175
Related to kobotoolbox/kpi#1738