### PR TITLE
Add compound index for fields `_userform_id` and `_id` to MongoDB

### DIFF
--- a/mongo/entrypoint.sh
+++ b/mongo/entrypoint.sh
@@ -11,6 +11,9 @@ cp $KOBO_DOCKER_SCRIPTS_DIR/init_* /docker-entrypoint-initdb.d/
 
 bash $KOBO_DOCKER_SCRIPTS_DIR/upsert_users.sh
 
+# Send post startup tasks in background to avoid blocking MongoDB startup
+bash $KOBO_DOCKER_SCRIPTS_DIR/post_startup.sh &
+
 echo "Launching official entrypoint..."
 # `exec` here is important to pass signals to the database server process;
 # without `exec`, the server will be terminated abruptly with SIGKILL (see #276)

--- a/mongo/init_01_add_index.sh
+++ b/mongo/init_01_add_index.sh
@@ -8,5 +8,6 @@ echo "Creating index for ${MONGO_INITDB_DATABASE}..."
 COL=instances
 
 echo "db.$COL.createIndex( { _userform_id: 1 } )" | mongo ${MONGO_INITDB_DATABASE}
+echo "db.$COL.createIndex( { _userform_id: 1, _id: -1 } )" | mongo ${MONGO_INITDB_DATABASE}
 
 echo "Done!"

--- a/mongo/post_startup.sh
+++ b/mongo/post_startup.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
-# Update users if database has been already created.
-# Users creation on init is left to `init_02_create_user.sh`
-BASE_DIR="$(readlink -f $(dirname "$BASH_SOURCE"))"
+# Create `_userform_id_id_` compound index in existing databases.
+# Creation in new databases is handled by `init_01_add_index.sh`.
+
 MONGO_CMD=( mongo --host 127.0.0.1 --port 27017 --quiet -u "$KOBO_MONGO_USERNAME" -p "$KOBO_MONGO_PASSWORD")
-MONGO_ADMIN_DATABASE=admin
 COLLECTION=instances
 
-while [ "$((echo > /dev/tcp/127.0.0.1/27017) >/dev/null 2>&1 && echo "1" || echo "0")" == "0" ]; do
+until (echo > /dev/tcp/127.0.0.1/27017) 2> /dev/null; do
     echo "Waiting for MongoDB to start...";
     sleep 30;
 done

--- a/mongo/post_startup.sh
+++ b/mongo/post_startup.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Update users if database has been already created.
+# Users creation on init is left to `init_02_create_user.sh`
+BASE_DIR="$(readlink -f $(dirname "$BASH_SOURCE"))"
+MONGO_CMD=( mongo --host 127.0.0.1 --port 27017 --quiet -u "$KOBO_MONGO_USERNAME" -p "$KOBO_MONGO_PASSWORD")
+MONGO_ADMIN_DATABASE=admin
+COLLECTION=instances
+
+while [ "$((echo > /dev/tcp/127.0.0.1/27017) >/dev/null 2>&1 && echo "1" || echo "0")" == "0" ]; do
+    echo "Waiting for MongoDB to start...";
+    sleep 30;
+done
+
+# MongoDB will skip the creation if index already exists.
+# It will return a note telling it already exists.
+# {
+#	"createdCollectionAutomatically" : false,
+#	"numIndexesBefore" : 2,
+#	"numIndexesAfter" : 2,
+#	"note" : "all indexes already exist",
+#	"ok" : 1
+# }
+create_compound_index() {
+    "${MONGO_CMD[@]}" "$MONGO_INITDB_DATABASE" <<-EOJS
+        db.$COLLECTION.createIndex({
+            _userform_id: 1,
+            _id: -1,
+        }, {
+            background: true
+        })
+EOJS
+}
+
+echo "Creating compound index for ${MONGO_INITDB_DATABASE} in background..."
+create_compound_index


### PR DESCRIPTION
## Description

MongoDB can be really slow when sorting or counting documents when the database contains lots of records and the query contains more than one index (e.g. `_userform_id` and `_id`). 
It happens because MongoDB does not know what index to choose and make sequential scans to read all the data - which is really slow on big database. 
Using a compound index of each field used in such queries make MongoDB return the data way faster. 

# Additional info

This new index is created when the DB is initialized. 
For retro-compatibility with existing installations, it is also created in background when MongoDB starts. MongoDB does not complain to create an index which already exists **if and only if** it's created with the same options. 