### PR TITLE
Update MongoDB entrypoint path

### DIFF
--- a/mongo/entrypoint.sh
+++ b/mongo/entrypoint.sh
@@ -14,4 +14,4 @@ bash $KOBO_DOCKER_SCRIPTS_DIR/upsert_users.sh
 echo "Launching official entrypoint..."
 # `exec` here is important to pass signals to the database server process;
 # without `exec`, the server will be terminated abruptly with SIGKILL (see #276)
-exec bash /entrypoint.sh mongod
+exec docker-entrypoint.sh mongod


### PR DESCRIPTION
Necessary because `/entrypoint.sh` is a symlink to `/usr/local/bin/docker-entrypoint.sh` in the Dockerfile for 3.4, but it's removed altogether in 3.6:

https://github.com/docker-library/mongo/blob/7eb154bcb0b90a70effe73dd8ab77783ce85434a/3.4/Dockerfile#L103
https://github.com/docker-library/mongo/blob/38648d9dddd6a6f87f0d47885bf6525c20b63557/3.6/Dockerfile#L107-L108

This does not break anything for 3.4 in my testing.

See also kobotoolbox/tasks#420