### PR TITLE
Update documentation to upgrade from PostgreSQL 9.4

### DIFF
--- a/doc/March-2019-Upgrade.md
+++ b/doc/March-2019-Upgrade.md
@@ -106,6 +106,7 @@ free.
 
 	```
 	apt-cache policy postgresql-9.4-postgis-2.5
+	POSTGIS_VERSION=$(apt-cache policy postgresql-9.4-postgis-2.5|grep Candidate:|awk '{print $2}')
 	apt-get install -y --no-install-recommends postgresql-9.4-postgis-2.5=${POSTGIS_VERSION} postgresql-9.4-postgis-2.5-scripts=${POSTGIS_VERSION}
 	apt-get upgrade
 	```
@@ -127,12 +128,12 @@ free.
 	 ```
 	 \c postgres;
 	 CREATE EXTENSION IF NOT EXISTS postgis;
-	 ALTER EXTENSION postgis UPDATE TO '2.5.0';
+	 ALTER EXTENSION postgis UPDATE TO '2.5.3';
 	 CREATE EXTENSION IF NOT EXISTS postgis_topology;
-	 ALTER EXTENSION postgis_topology UPDATE TO '2.5.0';
+	 ALTER EXTENSION postgis_topology UPDATE TO '2.5.3';
 	 CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 	 CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
-	 ALTER EXTENSION postgis_tiger_geocoder UPDATE TO '2.5.0';
+	 ALTER EXTENSION postgis_tiger_geocoder UPDATE TO '2.5.3';
 
 	 CREATE DATABASE template_postgis;
 	 UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
@@ -144,8 +145,8 @@ free.
 	 CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 
 	 \c kobotoolbox;
-	 ALTER EXTENSION postgis UPDATE TO '2.5.0';
-	 ALTER EXTENSION postgis_topology UPDATE TO '2.5.0';
+	 ALTER EXTENSION postgis UPDATE TO '2.5.3';
+	 ALTER EXTENSION postgis_topology UPDATE TO '2.5.3';
 	 CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;
 	 CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
 	 \q
@@ -217,11 +218,11 @@ free.
         image: kobotoolbox/postgres:latest
     ```
 
-    Change it to `mdillon/postgis:9.5` and comment `10_init_postgres.bash` script.
+    Change it to `postgis/postgis:9.5-2.5` and comment `10_init_postgres.bash` script.
 
     ```
     postgres:
-        image: mdillon/postgis:9.5
+        image: postgis/postgis:9.5-2.5
         ...
         volumes:
           ...

--- a/docker-compose.backend.template.yml
+++ b/docker-compose.backend.template.yml
@@ -1,4 +1,6 @@
-# For public, HTTPS servers.
+# Back-end containers template.
+# The primary and secondary compose files extend this file
+
 version: '2.2'
 
 services:


### PR DESCRIPTION
The documentation to upgrade PostgreSQL from `9.4` to `9.5` was a little bit outdated. 
When the documentation was written. The patch version for PostGIS `2.5` for PostgreSQL `9.4` and `9.5` was the same (i.e: `2.5.0`).
As of today (Oct 18, 2021). PostGIS 2.5 for PostgreSQL `9.4` is `2.5.3` and `2.5.5` for PostgreSQL `9.5`