### PR TITLE
Run KPI uWSGI workers as a non-root user

### DIFF
--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -5,7 +5,7 @@ version: '3'
 
 services:
   kobocat:
-    image: kobotoolbox/kobocat:2.021.41
+    image: kobotoolbox/kobocat:2.021.47
     hostname: kobocat
     env_file:
       - ../kobo-env/envfile.txt
@@ -44,7 +44,7 @@ services:
           - kobocat.internal
 
   kpi:
-    image: kobotoolbox/kpi:2.021.41
+    image: kobotoolbox/kpi:2.021.47
     hostname: kpi
     env_file:
       - ../kobo-env/envfile.txt

--- a/uwsgi/kpi_uwsgi.ini
+++ b/uwsgi/kpi_uwsgi.ini
@@ -62,8 +62,8 @@ socket          = 0.0.0.0:8000
 buffer-size     = 32768
 listen          = @(/proc/sys/net/core/somaxconn)
 
-#uid             = wsgi
-#gid             = wsgi
+uid             = $(UWSGI_USER)
+gid             = $(UWSGI_GROUP)
 die-on-term     = true
 
 # uWSGI does not pass locale information to the application by default


### PR DESCRIPTION
KPI uWSGI configuration (`uwsgi.ini`) was running as user with priviliges unlike KoBoCAT configuration.

This requires changes in the KPI Docker, so that the user is set within the build.

- [x] review and merge kobotoolbox/kpi#3520 
- [x] make new release with these changes
- [ ] update this PR so that `docker-compose.frontend.yml` uses the new release
- [ ] merge this PR

