### PR TITLE
Make redis containers start up instantly

### DIFF
--- a/redis/entrypoint.sh
+++ b/redis/entrypoint.sh
@@ -17,12 +17,10 @@ if [[ ! -d "$REDIS_DATA_DIR" ]]; then
     mkdir -p "$REDIS_DATA_DIR"
 fi
 
-# install envsubst
-apt-get update && apt-get -y install gettext-base
-
-cat "$REDIS_CONF_FILE.tmpl" \
-      | envsubst '${CONTAINER_IP} ${REDIS_PASSWORD} ${REDIS_CACHE_MAX_MEMORY}' \
-        > "$REDIS_CONF_FILE"
+awk '{ gsub(/\${CONTAINER_IP}/,ENVIRON["CONTAINER_IP"])
+       gsub(/\${REDIS_PASSWORD}/,ENVIRON["REDIS_PASSWORD"])
+       gsub(/\${REDIS_CACHE_MAX_MEMORY}/,ENVIRON["REDIS_CACHE_MAX_MEMORY"])
+       print }' "$REDIS_CONF_FILE.tmpl" > "$REDIS_CONF_FILE"
 
 if [[ -z "$REDIS_PASSWORD" ]]; then
     sed -i 's/requirepass ""//g' "$REDIS_CONF_FILE"


### PR DESCRIPTION
This patch removes the `apt-get` calls from `redis/entrypoint.sh`, reducing the redis start-up time to nearly 0.

On my network (I'm in Africa), the calls to `apt-get update && apt-get -y install gettext-base` in `redis/entrypoint.sh` are the main reason for the slow startup of Kobo. When the network fails, or the backend server is isolated from the internet (as it should be), it fails to start up altogether.

This patch replaces the call to `envsubst` by an `awk` program that does the same. Note that the `ENVIRON` array and `gsub` are POSIX awk, so this works for any awk.

