### PR TITLE
Add ".uniqid" to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docker-compose.yml
 start-env.sh
 stop-env.sh
 nginx/maintenance/index.html
+.uniqid


### PR DESCRIPTION
kobo-install creates a file which contains random unique string for internal purpose. 
To avoid adding to this repo, let's add it to .gitignore.