### PR TITLE
Fix NGINX DNS cache resolution issue

### DIFF
--- a/nginx/kobo-docker-scripts/templates/uwsgi_pass.conf.tmpl
+++ b/nginx/kobo-docker-scripts/templates/uwsgi_pass.conf.tmpl
@@ -3,7 +3,13 @@
 
 uwsgi_read_timeout ${UWSGI_PASS_TIMEOUT};
 uwsgi_send_timeout ${UWSGI_PASS_TIMEOUT};
-uwsgi_pass ${container_name}:${container_port};
+
+# Nginx DNS resolution issue fix
+# See https://www.jethrocarr.com/2013/11/02/nginx-reverse-proxies-and-dns-resolution/
+# 127.0.0.11 is internal docker DNS server (see `cat /etc/resolv.conf`)
+resolver 127.0.0.11 ipv6=off valid=1s;
+set $upstream "${container_name}:${container_port}";
+uwsgi_pass $upstream;
 # For setting HTTP headers, see http://stackoverflow.com/a/14133533/1877326.
 uwsgi_param HTTP_X_REAL_IP $remote_addr;
 uwsgi_param HTTP_X_FORWARDED_FOR $remote_addr;


### PR DESCRIPTION
## Description

Avoid NGINX to send KoBoCAT traffic to KPI container and vice versa

## Additional info

Force NGINX to resolve `kpi` and `kobocat` domain names on the docker network on every proxied request.

## Related issues

Closes #332 