### PR TITLE
Set username and password when calling `pg_isready`

### DIFF
--- a/scripts/wait_for_postgres.bash
+++ b/scripts/wait_for_postgres.bash
@@ -9,15 +9,15 @@ echo 'Waiting for Postgres service.'
 # TODO: There must be a way to confirm Postgres is serving without the resulting "incomplete startup packet" warning in the logs.
 POSTGRES_DB="${POSTGRES_DB:-kobotoolbox}"
 POSTGRES_USER="${POSTGRES_USER:-kobo}"
-until pg_isready -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}"; do
+export PGPASSWORD="${POSTGRES_PASSWORD:-kobo}"
+until pg_isready -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -U "${POSTGRES_USER}"; do
     sleep 1
 done
 
 source /etc/profile
 
 echo "Postgres service running; ensuring ${POSTGRES_DB} database exists and has PostGIS extensions..."
-PGPASSWORD="${POSTGRES_PASSWORD:-kobo}" psql \
-    -d postgres -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -U "${POSTGRES_USER}" <<EOF
+psql -d postgres -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -U "${POSTGRES_USER}" <<EOF
 CREATE DATABASE "$POSTGRES_DB" OWNER "$POSTGRES_USER";
 \c "$POSTGRES_DB"
 CREATE EXTENSION IF NOT EXISTS postgis;


### PR DESCRIPTION
This gets rid of scary-looking PostgreSQL log entries like:

    LOG:  incomplete startup packet
    FATAL:  password authentication failed for user "root"
    DETAIL:  Role "root" does not exist.
            Connection matched pg_hba.conf line 15: "host    all all all md5"