### PR TITLE
Fix wrong scheme with HTTPS when using Django development web server

### DIFF
--- a/nginx/kobo-docker-scripts/templates/proxy_pass.conf.tmpl
+++ b/nginx/kobo-docker-scripts/templates/proxy_pass.conf.tmpl
@@ -5,7 +5,6 @@ proxy_pass http://${container_name}:${container_port};
 proxy_set_header Host $host:$proxy_port;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $remote_addr;
-proxy_set_header X-Forwarded-Proto $scheme;
 proxy_set_header X-Forwarded-Host ${container_x_forwarded_host}${container_public_port};
 proxy_redirect off;
 


### PR DESCRIPTION
## Description

Let the HTTPS reverse proxy send the correct value


## Notes
Only affect dev environment when using NGINX with Django webserver. 
It's useful for Django to set the correct value based on `SECURE_PROXY_SSL_HEADER` env variable.