### PR TITLE
Remove nginx version from response header

### DIFF
--- a/nginx/kobo-docker-scripts/nginx.conf
+++ b/nginx/kobo-docker-scripts/nginx.conf
@@ -20,7 +20,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     types_hash_max_size 2048;
-    # server_tokens off;
+    server_tokens off;
 
     server_names_hash_bucket_size 64;
     # server_name_in_redirect off;


### PR DESCRIPTION
Removes the nginx version from the `server` response header by setting server_tokens off in nginx.conf.
Tested normal and maintenance mode using kobo-install.