### PR TITLE
fix: remove the obsolete version attribute

### DIFF
--- a/docker-compose.backend.override.yml.sample
+++ b/docker-compose.backend.override.yml.sample
@@ -1,6 +1,4 @@
 # Override for back-end server
-version: '3'
-
 services:
 
   postgres:

--- a/docker-compose.backend.yml
+++ b/docker-compose.backend.yml
@@ -1,6 +1,4 @@
 # Back-end containers
-version: '3'
-
 services:
   postgres:
     image: postgis/postgis:14-3.2

--- a/docker-compose.frontend.override.yml.sample
+++ b/docker-compose.frontend.override.yml.sample
@@ -1,6 +1,4 @@
 # Override for front-end servers
-version: '3'
-
 services:
   kpi:
     environment:

--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -1,8 +1,6 @@
 # NOTE: Generate `../kobo-env/` environment files using
 # https://github.com/kobotoolbox/kobo-install. You may manually customize the
 # files afterwards and stop using kobo-install if necessary.
-version: '3'
-
 services:
   kpi: &django
     image: kobotoolbox/kpi:2.024.25c

--- a/docker-compose.maintenance.override.yml.sample
+++ b/docker-compose.maintenance.override.yml.sample
@@ -1,6 +1,4 @@
 # For public, HTTPS servers.
-version: '3'
-
 services:
 
   maintenance:

--- a/docker-compose.maintenance.yml
+++ b/docker-compose.maintenance.yml
@@ -1,6 +1,4 @@
 # For public, HTTPS servers.
-version: '3'
-
 services:
 
   maintenance:


### PR DESCRIPTION
Avoid potential confusion on running `./run.py` from `kobo-install` as suggested by the warning message.

### before
```
$ ./run.py 
WARN[0000] /<redacted-path>/kobo-docker/docker-compose.maintenance.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
WARN[0000] /<redacted-path>/kobo-docker/tmp01/docker-compose.maintenance.override.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
WARN[0000] /<redacted-path>/kobo-docker/tmp01/docker-compose.frontend.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
WARN[0000] /<redacted-path>/kobo-docker/tmp01/docker-compose.frontend.override.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
WARN[0000] /<redacted-path>/kobo-docker/tmp01/docker-compose.maintenance.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
WARN[0000] /<redacted-path>/kobo-docker/tmp01/docker-compose.maintenance.override.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
WARN[0000] /<redacted-path>/kobo-docker/tmp01/docker-compose.backend.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
WARN[0000] /<redacted-path>/kobo-docker/tmp01/docker-compose.backend.override.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Running 5/5
...
```
### after
```
$ ./run.py 
[+] Running 5/5
...
```
