### PR TITLE
fix(celery): correct Celery Beat entrypoint path

### DIFF
--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -56,7 +56,7 @@ services:
 
   beat:
     <<: *django
-    command: ['bash', '/srv/src/kpi/docker/entrypoint_celery_kobocat_worker.bash']
+    command: ['bash', '/srv/src/kpi/docker/entrypoint_celery_beat.bash']
 
   nginx:
     image: nginx:1.26


### PR DESCRIPTION
### Summary 
Fixed an issue with the incorrect path in the Celery Beat entrypoint.

### Description
The Celery Beat entrypoint was misconfigured due to an incorrect path, preventing scheduled tasks from initializing correctly.