### PR TITLE
Fix syntax for index creation in init_01_add_index.sh

### DIFF
--- a/mongo/init_01_add_index.sh
+++ b/mongo/init_01_add_index.sh
@@ -9,7 +9,7 @@ COL=instances
 
 echo "db.$COL.createIndex( { _userform_id: 1 } )" | mongo ${MONGO_INITDB_DATABASE}
 echo "db.$COL.createIndex( { _userform_id: 1, _id: -1 } )" | mongo ${MONGO_INITDB_DATABASE}
-echo "db.$COL.createIndex( { formhub/uuid: 1 } )" | mongo ${MONGO_INITDB_DATABASE}
+echo "db.$COL.createIndex( { \"formhub/uuid\": 1 } )" | mongo ${MONGO_INITDB_DATABASE}
 echo "db.$COL.createIndex( { _userform_id: 1, _submission_time: 1 } )" | mongo ${MONGO_INITDB_DATABASE}
 echo "db.$COL.createIndex( { _xform_id_string: 1 } )" | mongo ${MONGO_INITDB_DATABASE}
 


### PR DESCRIPTION
add double-quotes to index name "formhub/uuid" to prevent syntax error during startup of mongo container

this error makes the mongo default entry-point script /usr/local/bin/docker-entrypoint.sh aborts pre-maturely
which results in not executing the second init script init_02_create_user.sh which creates kobo user