### PR TITLE
Correct discrepancy in MongoDB index

### DIFF
--- a/mongo/init_01_add_index.sh
+++ b/mongo/init_01_add_index.sh
@@ -10,7 +10,7 @@ COL=instances
 echo "db.$COL.createIndex( { _userform_id: 1 } )" | mongo ${MONGO_INITDB_DATABASE}
 echo "db.$COL.createIndex( { _userform_id: 1, _id: -1 } )" | mongo ${MONGO_INITDB_DATABASE}
 echo "db.$COL.createIndex( { \"formhub/uuid\": 1 } )" | mongo ${MONGO_INITDB_DATABASE}
-echo "db.$COL.createIndex( { _userform_id: 1, _submission_time: 1 } )" | mongo ${MONGO_INITDB_DATABASE}
+echo "db.$COL.createIndex( { _userform_id: 1, _submission_time: -1 } )" | mongo ${MONGO_INITDB_DATABASE}
 echo "db.$COL.createIndex( { _xform_id_string: 1 } )" | mongo ${MONGO_INITDB_DATABASE}
 
 echo "Done!"


### PR DESCRIPTION
The typical query gets latest submissions first, so descending order on the submission time is correct