### PR TITLE
fix: redirect root of KoboCAT domain name to KPI domain name

### DIFF
--- a/nginx/kobo-docker-scripts/templates/nginx_site_default.conf.tmpl
+++ b/nginx/kobo-docker-scripts/templates/nginx_site_default.conf.tmpl
@@ -122,6 +122,12 @@ server {
 
     include /etc/nginx/includes/protected_directive.conf;
 
+    # Redirect root (only) to KPI
+    location = / {
+        return 301 $scheme://${KOBOFORM_PUBLIC_SUBDOMAIN}.${PUBLIC_DOMAIN_NAME}/;
+    }
+
+    # Return 404 for everything else
     location / {
         return 404;
     }


### PR DESCRIPTION
### 📣 Summary
Redirect root of KoboCAT domain name to KPI domain name. Other URLs, not whitelisted, still return a 404.
It matches k8s production NGINX settings
