### PR TITLE
Call the standard Redis entrypoint script DEV-2158

### DIFF
--- a/redis/entrypoint.sh
+++ b/redis/entrypoint.sh
@@ -42,7 +42,8 @@ if [[ "$KOBO_REDIS_SERVER_ROLE" == "main" ]]; then
     /bin/bash "$KOBO_DOCKER_SCRIPTS_DIR/toggle-backup-activation.sh" &
 fi
 
-# `exec` and `gosu` (vs. `su`) here are important to pass signals to the
-# database server process; without them, the server will be terminated abruptly
-# with SIGKILL (see #276)
-exec gosu redis redis-server /etc/redis/redis.conf
+# `exec` here is important to pass signals to the standard entrypoint script;
+# without it, the server will be terminated abruptly with SIGKILL (see #276)
+# For reference, the standard entrypoint script can be found at:
+# https://github.com/redis/docker-library-redis/blob/release/7.2/debian/docker-entrypoint.sh
+exec docker-entrypoint.sh /etc/redis/redis.conf


### PR DESCRIPTION
…from our script, instead of starting `redis-server` directly. That way, we *might* be more resilient to upstream Redis doing something frustrating like removing `gosu` spontaneously in patch release 7.2.14 (it was present in 7.2.13). See redis/docker-library-redis#435. Even though that PR makes it appear the intent was to affect Redis 8 only, viewing the commit shows the change was applied all the way down to Redis 6.2.22: https://github.com/redis/docker-library-redis/commit/3b9471e7803ad7773bb2926ebc6535bec78ac3ce