### PR TITLE
Upgrade to MongoDB 8 INFRA-491

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 1. [_Two PostgreSQL databases are now required_](#two-postgresql-databases-are-now-required)
 1. [Important notice when upgrading from commit `5c2ef02` (March 4, 2019) or earlier](#important-notice-when-upgrading-from-commit-5c2ef02-march-4-2019-or-earlier)
 1. [Important notice when upgrading from commit between `51aeccb` (March 11, 2019) and `2.022.44` (November 17, 2022)](#important-notice-when-upgrading-from-commit-between-51aeccb-march-11-2019-and-202244-november-17-2022)
+1. [Important notice when upgrading from commit `TBC` (June x, 2026) or earlier](#important-notice-when-upgrading-june-2026)
 1. [Architecture](#architecture)
 1. [Setup procedure](#setup-procedure)
 1. [Usage](#usage)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Running current releases of KoboToolbox requires you to upgrade your PostgreSQL 
 
 If you do not, the application may not start or your data may not be visible.
 
+## Important notice when upgrading from commit `TBC` (June x, 2026) or earlier
+
+Running current releases of KoboToolbox requires you to upgrade your MongoDB database. Please follow [these instructions](./doc/June-2026-Upgrade-MongoDB8.md).
+
+If you do not, the application may not start or your data may not be visible.
+
 ## Architecture
 
 Below is a diagram (made with [Lucidchart](https://www.lucidchart.com)) of the containers that make up a running kobo-docker system and their connections.

--- a/doc/June-2026-Upgrade-MongoDB8.md
+++ b/doc/June-2026-Upgrade-MongoDB8.md
@@ -1,0 +1,74 @@
+## Upgrading from MongoDB 5.0 to 8.0
+
+In June 2026, kobo-docker was updated to use MongoDB 8.
+If you have not performed these steps, you must follow these one-time instructions to upgrade from MongoDB 5 to MongoDB 8. To do so you must upgrade to version 6, 7, and then 8 - you **CANNOT** skip versions when migrating.  This upgrade process does incur downtime until it is complete.
+
+While the MongoDB version change is within kobo-docker, the commands shown below are for [kobo-install](https://github.com/kobotoolbox/kobo-install) and expected to be run in the directory containing kobo-install.
+
+### Upgrading MongoDB
+
+**Upgrading Mongo is easy and only requires several stops and starts**
+
+1. Important: Before starting, back up your MongoDB data volumes. Upgrading between major versions can cause data loss if something goes wrong.
+
+1. Upgrade to 6.0
+
+    1. Stop `mongo` container
+
+        ```shell
+        user@computer:kobo-install$ python3 run.py -cb stop mongo
+        ```
+
+    1. Edit compose file `docker-compose.backend.yml` and change the mongo image to `mongo:6.0` (it should contain `mongo:8.0`)
+
+        ```
+        mongo:
+          image: mongo:6.0
+        ```
+
+    1. Start the container:
+
+        ```shell
+        user@computer:kobo-install$ python3 run.py -cb up --force-recreate mongo -d
+           ```
+
+    1. Wait for MongoDB to be ready. You should see a "startup complete" message in the logs: `python3 run.py -cb logs mongo -f | grep "mongod startup complete"`
+
+    1. From another terminal, enter the container using `python3 run.py --compose-backend exec mongo bash` and update compatibility version.
+        For version 6.0: 
+        ```shell
+        root@mongo:/# mongosh -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" admin
+        admin> db.adminCommand( { setFeatureCompatibilityVersion: "6.0" } )
+        { "ok" : 1 }
+        > exit
+        bye
+        root@mongo:/# exit
+        ```
+
+        For version 7.0/8.0 (change version accordingly):
+        ```shell
+        root@mongo:/# mongosh -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" admin
+        admin> db.adminCommand( { setFeatureCompatibilityVersion: "7.0", confirm: true } )
+        { "ok" : 1 }
+        > exit
+        bye
+        root@mongo:/# exit
+        ```
+
+1. Upgrade to 7.0, 8.0
+
+    Repeat the steps above for each version and replace the version accordingly.
+    You **must** upgrade each version one by one.
+
+
+### Tests
+
+1. Test if upgrade is successful
+
+    Start your containers as usual.
+
+    ```shell
+    user@computer:kobo-install$ python3 run.py
+    ```
+
+    Log into one of your user accounts and validate everything is working as expected.

--- a/doc/June-2026-Upgrade-MongoDB8.md
+++ b/doc/June-2026-Upgrade-MongoDB8.md
@@ -40,7 +40,7 @@ While the MongoDB version change is within kobo-docker, the commands shown below
         root@mongo:/# mongosh -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" admin
         admin> db.adminCommand( { setFeatureCompatibilityVersion: "6.0" } )
         { "ok" : 1 }
-        > exit
+        admin> exit
         bye
         root@mongo:/# exit
         ```
@@ -50,7 +50,7 @@ While the MongoDB version change is within kobo-docker, the commands shown below
         root@mongo:/# mongosh -u "$MONGO_INITDB_ROOT_USERNAME" -p "$MONGO_INITDB_ROOT_PASSWORD" admin
         admin> db.adminCommand( { setFeatureCompatibilityVersion: "7.0", confirm: true } )
         { "ok" : 1 }
-        > exit
+        admin> exit
         bye
         root@mongo:/# exit
         ```

--- a/docker-compose.backend.yml
+++ b/docker-compose.backend.yml
@@ -18,7 +18,7 @@ services:
     stop_grace_period: 5m
 
   mongo:
-    image: mongo:5.0
+    image: mongo:8.0
     hostname: mongo
     environment:
       - MONGO_DATA=/data/db

--- a/mongo/init_02_create_user.sh
+++ b/mongo/init_02_create_user.sh
@@ -2,7 +2,7 @@
 
 echo "Creating user for ${MONGO_INITDB_DATABASE}..."
 
-mongo=( mongo --host 127.0.0.1 --port 27017 --quiet )
+mongo=( mongosh --host 127.0.0.1 --port 27017 --quiet )
 
 _js_escape() {
 	jq --null-input --arg 'str' "$1" '$str'

--- a/mongo/post_startup.sh
+++ b/mongo/post_startup.sh
@@ -2,7 +2,7 @@
 # Create `_userform_id_id_` compound index in existing databases.
 # Creation in new databases is handled by `init_01_add_index.sh`.
 
-MONGO_CMD=( mongo --host 127.0.0.1 --port 27017 --quiet -u "$KOBO_MONGO_USERNAME" -p "$KOBO_MONGO_PASSWORD")
+MONGO_CMD=( mongosh --host 127.0.0.1 --port 27017 --quiet -u "$KOBO_MONGO_USERNAME" -p "$KOBO_MONGO_PASSWORD")
 COLLECTION=instances
 
 until (echo > /dev/tcp/127.0.0.1/27017) 2> /dev/null; do

--- a/mongo/upsert_users.sh
+++ b/mongo/upsert_users.sh
@@ -2,7 +2,7 @@
 # Update users if database has been already created.
 # Users creation on init is left to `init_02_create_user.sh`
 BASE_DIR="$(readlink -f $(dirname "$BASH_SOURCE"))"
-MONGO_CMD=( mongo --host 127.0.0.1 --port 27017 --quiet )
+MONGO_CMD=( mongosh --host 127.0.0.1 --port 27017 --quiet )
 MONGO_ADMIN_DATABASE=admin
 UPSERT_DB_USERS_TRIGGER_FILE=".upsert_db_users"
 


### PR DESCRIPTION
This updates MongoDB to version 8 and adds instructions for the manual steps that need to be performed.

**BREAKING CHANGE** after merging, users must upgrade their mongodb files using the process described in the document.

After merge another commit will be done to update the readme with the actual commit SHA