### PR TITLE
chore(env): rename KOBO_SUPPORT_EMAIL to CONSTANCE_SUPPORT_EMAIL DEV-1976

### DIFF
--- a/env/envfiles/django.txt
+++ b/env/envfiles/django.txt
@@ -23,7 +23,7 @@ KOBO_SUPERUSER_USERNAME=super_admin
 # The initial superuser's password.
 KOBO_SUPERUSER_PASSWORD=changeme!!
 # The e-mail address where your users can contact you.
-KOBO_SUPPORT_EMAIL=support@domain.name
+CONSTANCE_SUPPORT_EMAIL=support@domain.name
 
 KOBOFORM_URL=https://kf.domain.name
 KOBOFORM_INTERNAL_URL=http://kf.kobo.internal # Always use HTTP internally.


### PR DESCRIPTION
### 🔗 Related PRs
Part of a 3-repo Constance env-var standardization:
- **kobotoolbox/kpi#7230** — the app-side rename (reads `CONSTANCE_SUPPORT_EMAIL`)
- **kobotoolbox/kobo-install#279** — same rename in the kobo-install env template

kpi keeps backward compatibility (old names still read, with a `DeprecationWarning`), so this can land independently — it simply migrates the default env file to the new name.

### Description
Renames `KOBO_SUPPORT_EMAIL` → `CONSTANCE_SUPPORT_EMAIL` in the default django env file. Only the var name changes; the value is unchanged.