### PR TITLE
fix: nginx upload limit 105M for Enketo video (#172)

### DIFF
--- a/nginx/kobo-docker-scripts/include.server_directive_common.conf
+++ b/nginx/kobo-docker-scripts/include.server_directive_common.conf
@@ -1,5 +1,5 @@
-    # Allow 100M upload
-    client_max_body_size 100M;
+    # Allow 105M uploads (100M attachment + multipart overhead; see #172)
+    client_max_body_size 105M;
 
     # Support bigger headers. Useful for huge cookies
     large_client_header_buffers 8 16k;


### PR DESCRIPTION
## Summary
- Increase `client_max_body_size` from 100M to 105M in `include.server_directive_common.conf` to allow headroom for 100M attachments plus multipart/XML overhead.

Note: the `X-OpenRosa-Accept-Content-Length` header is controlled in KoBoCAT ([kobocat#435](https://github.com/kobotoolbox/kobocat/issues/435)); this PR covers the nginx side only.

## Test plan
- [ ] Restart nginx container after deploy
- [ ] Upload a large video attachment near 100M through Enketo and confirm nginx accepts the request

Fixes #172 (nginx portion)

Made with [Cursor](https://cursor.com)