### PR TITLE
fix(mongo): fix mongo init scripts

### DIFF
--- a/mongo/init_01_add_index.sh
+++ b/mongo/init_01_add_index.sh
@@ -7,10 +7,10 @@ echo "Creating index for ${MONGO_INITDB_DATABASE}..."
 
 COL=instances
 
-echo "db.$COL.createIndex( { _userform_id: 1 } )" | mongosh ${MONGO_INITDB_DATABASE}
-echo "db.$COL.createIndex( { _userform_id: 1, _id: -1 } )" | mongosh ${MONGO_INITDB_DATABASE}
-echo "db.$COL.createIndex( { \"formhub/uuid\": 1 } )" | mongosh ${MONGO_INITDB_DATABASE}
-echo "db.$COL.createIndex( { _userform_id: 1, _submission_time: -1 } )" | mongosh ${MONGO_INITDB_DATABASE}
-echo "db.$COL.createIndex( { _xform_id_string: 1 } )" | mongosh ${MONGO_INITDB_DATABASE}
+echo "db.$COL.createIndex( { _userform_id: 1 } )" | mongosh "$MONGO_INITDB_DATABASE"
+echo "db.$COL.createIndex( { _userform_id: 1, _id: -1 } )" | mongosh "$MONGO_INITDB_DATABASE"
+echo "db.$COL.createIndex( { \"formhub/uuid\": 1 } )" | mongosh "$MONGO_INITDB_DATABASE"
+echo "db.$COL.createIndex( { _userform_id: 1, _submission_time: -1 } )" | mongosh "$MONGO_INITDB_DATABASE"
+echo "db.$COL.createIndex( { _xform_id_string: 1 } )" | mongosh "$MONGO_INITDB_DATABASE"
 
 echo "Done!"

--- a/mongo/init_01_add_index.sh
+++ b/mongo/init_01_add_index.sh
@@ -7,10 +7,10 @@ echo "Creating index for ${MONGO_INITDB_DATABASE}..."
 
 COL=instances
 
-echo "db.$COL.createIndex( { _userform_id: 1 } )" | mongo ${MONGO_INITDB_DATABASE}
-echo "db.$COL.createIndex( { _userform_id: 1, _id: -1 } )" | mongo ${MONGO_INITDB_DATABASE}
-echo "db.$COL.createIndex( { \"formhub/uuid\": 1 } )" | mongo ${MONGO_INITDB_DATABASE}
-echo "db.$COL.createIndex( { _userform_id: 1, _submission_time: -1 } )" | mongo ${MONGO_INITDB_DATABASE}
-echo "db.$COL.createIndex( { _xform_id_string: 1 } )" | mongo ${MONGO_INITDB_DATABASE}
+echo "db.$COL.createIndex( { _userform_id: 1 } )" | mongosh ${MONGO_INITDB_DATABASE}
+echo "db.$COL.createIndex( { _userform_id: 1, _id: -1 } )" | mongosh ${MONGO_INITDB_DATABASE}
+echo "db.$COL.createIndex( { \"formhub/uuid\": 1 } )" | mongosh ${MONGO_INITDB_DATABASE}
+echo "db.$COL.createIndex( { _userform_id: 1, _submission_time: -1 } )" | mongosh ${MONGO_INITDB_DATABASE}
+echo "db.$COL.createIndex( { _xform_id_string: 1 } )" | mongosh ${MONGO_INITDB_DATABASE}
 
 echo "Done!"


### PR DESCRIPTION
This fixes an issue with the mongo init scripts that came up after the mongo 8 upgrade.

Prior to mongo 8, `mongo` was available but it is no longer available in version 8.  One of the init scripts missed being updated to use `mongosh` instead which caused an issue when spinning up a new instance.  This resolves that.

Tested both on a new instance and upgrading an old instance and it worked in both cases.