### PR TITLE
chore(mongo): add root_uuid indexes, disable dead ones

### DIFF
--- a/mongo/init_01_add_index.sh
+++ b/mongo/init_01_add_index.sh
@@ -7,10 +7,21 @@ echo "Creating index for ${MONGO_INITDB_DATABASE}..."
 
 COL=instances
 
-echo "db.$COL.createIndex( { _userform_id: 1 } )" | mongosh "$MONGO_INITDB_DATABASE"
+# Primary submission list query + default sort by `_id`.
 echo "db.$COL.createIndex( { _userform_id: 1, _id: -1 } )" | mongosh "$MONGO_INITDB_DATABASE"
-echo "db.$COL.createIndex( { \"formhub/uuid\": 1 } )" | mongosh "$MONGO_INITDB_DATABASE"
+# Sort submissions by submission date.
 echo "db.$COL.createIndex( { _userform_id: 1, _submission_time: -1 } )" | mongosh "$MONGO_INITDB_DATABASE"
-echo "db.$COL.createIndex( { _xform_id_string: 1 } )" | mongosh "$MONGO_INITDB_DATABASE"
+# Lookup a submission by its root_uuid (edit links, permalinks).
+echo "db.$COL.createIndex( { \"meta/rootUuid\": 1, _id: 1 }, { name: \"rootUuid_id_idx\" } )" | mongosh "$MONGO_INITDB_DATABASE"
+# Backfill scan for submissions still missing root_uuid (long-running migration 0028).
+echo "db.$COL.createIndex( { _id: 1, \"meta/rootUuid\": 1 }, { name: \"id_rootUuid_idx\" } )" | mongosh "$MONGO_INITDB_DATABASE"
+# Fallback lookup by `_uuid` when root_uuid isn't set (legacy submissions).
+echo "db.$COL.createIndex( { _userform_id: 1, _uuid: 1 } )" | mongosh "$MONGO_INITDB_DATABASE"
+
+# The only code that queried these two (kobo/apps/trash_bin/utils/project.py::
+# _delete_submissions) is dead (unreachable, raises before reaching that query).
+# Drop them on existing deployments; do not recreate.
+# echo "db.$COL.createIndex( { \"formhub/uuid\": 1 } )" | mongosh "$MONGO_INITDB_DATABASE"
+# echo "db.$COL.createIndex( { _xform_id_string: 1 } )" | mongosh "$MONGO_INITDB_DATABASE"
 
 echo "Done!"

--- a/mongo/post_startup.sh
+++ b/mongo/post_startup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Create `_userform_id_id_` compound index in existing databases.
+# Create/update the required indexes on `instances` in existing databases.
 # Creation in new databases is handled by `init_01_add_index.sh`.
 
 MONGO_CMD=( mongosh --host 127.0.0.1 --port 27017 --quiet -u "$KOBO_MONGO_USERNAME" -p "$KOBO_MONGO_PASSWORD")
@@ -19,6 +19,8 @@ done
 #	"note" : "all indexes already exist",
 #	"ok" : 1
 # }
+
+# Primary submission list query + default sort by `_id`.
 create_userform_id_and_id_index() {
     "${MONGO_CMD[@]}" "$MONGO_INITDB_DATABASE" <<-EOJS
         db.$COLLECTION.createIndex({
@@ -30,17 +32,7 @@ create_userform_id_and_id_index() {
 EOJS
 }
 
-create_formhub_uuid_index() {
-  "${MONGO_CMD[@]}" "$MONGO_INITDB_DATABASE" <<-EOJS
-        db.$COLLECTION.createIndex({
-            'formhub/uuid': 1,
-        }, {
-            background: true
-        })
-EOJS
-}
-
-
+# Sort submissions by submission date.
 create_userform_id_and_submission_time_index() {
     "${MONGO_CMD[@]}" "$MONGO_INITDB_DATABASE" <<-EOJS
         db.$COLLECTION.createIndex({
@@ -52,18 +44,72 @@ create_userform_id_and_submission_time_index() {
 EOJS
 }
 
-create_xform_id_string_index() {
+# Lookup a submission by its root_uuid (edit links, permalinks).
+create_root_uuid_index() {
     "${MONGO_CMD[@]}" "$MONGO_INITDB_DATABASE" <<-EOJS
         db.$COLLECTION.createIndex({
-            _xform_id_string: 1,
+            'meta/rootUuid': 1,
+            _id: 1,
+        }, {
+            name: 'rootUuid_id_idx',
+            background: true
+        })
+EOJS
+}
+
+# Backfill scan for submissions still missing root_uuid (long-running migration 0028).
+create_id_root_uuid_index() {
+    "${MONGO_CMD[@]}" "$MONGO_INITDB_DATABASE" <<-EOJS
+        db.$COLLECTION.createIndex({
+            _id: 1,
+            'meta/rootUuid': 1,
+        }, {
+            name: 'id_rootUuid_idx',
+            background: true
+        })
+EOJS
+}
+
+# Fallback lookup by `_uuid` when root_uuid isn't set (legacy submissions).
+create_userform_id_and_uuid_index() {
+    "${MONGO_CMD[@]}" "$MONGO_INITDB_DATABASE" <<-EOJS
+        db.$COLLECTION.createIndex({
+            _userform_id: 1,
+            _uuid: 1,
         }, {
             background: true
         })
 EOJS
 }
 
+# The only code that queried these two (kobo/apps/trash_bin/utils/project.py::
+# _delete_submissions) is dead (unreachable, raises before reaching that query).
+# Drop them on existing deployments; do not recreate.
+# create_formhub_uuid_index() {
+#     "${MONGO_CMD[@]}" "$MONGO_INITDB_DATABASE" <<-EOJS
+#         db.$COLLECTION.createIndex({
+#             'formhub/uuid': 1,
+#         }, {
+#             background: true
+#         })
+# EOJS
+# }
+#
+# create_xform_id_string_index() {
+#     "${MONGO_CMD[@]}" "$MONGO_INITDB_DATABASE" <<-EOJS
+#         db.$COLLECTION.createIndex({
+#             _xform_id_string: 1,
+#         }, {
+#             background: true
+#         })
+# EOJS
+# }
+
 echo "Creating new indexes for ${MONGO_INITDB_DATABASE} in background..."
 create_userform_id_and_id_index
-create_formhub_uuid_index
 create_userform_id_and_submission_time_index
-create_xform_id_string_index
+create_root_uuid_index
+create_id_root_uuid_index
+create_userform_id_and_uuid_index
+# create_formhub_uuid_index
+# create_xform_id_string_index


### PR DESCRIPTION
## Summary 
  
Update the `instances` collection index set created at Mongo startup, based on an audit of what the KPI code (backend + frontend) actually queries.

## Notes

Index behavior (including the query-plan analysis behind the `id_rootUuid_idx` field ordering) was verified live against production servers via `explain()`.