### PR TITLE
fix: tolerate trailing slash on OpenRosa /submission location (DEV-1039)

### DIFF
--- a/nginx/kobo-docker-scripts/templates/nginx_site_default.conf.tmpl
+++ b/nginx/kobo-docker-scripts/templates/nginx_site_default.conf.tmpl
@@ -86,7 +86,7 @@ server {
     # /formUpload
     # /submission
     # /upload
-    location ~ ^/(formList|formUpload|submission|upload)$ {
+    location ~ ^/(formList|formUpload|submission|upload)/?$ {
         # Proxy through uWSGI or Django webserver
         include /etc/nginx/includes/proxy_pass.conf;
     }


### PR DESCRIPTION
### 📣 Summary

OpenRosa submissions posted to `…/submission/` (with a trailing slash) no longer 404 at nginx before reaching the backend.

### 📖 Description

On the `kc.kobo.local` (kobocat/OpenRosa) server, `POST /submission/` used to return an nginx `404` while `/submission` (no slash) worked. The root-level OpenRosa `location` regex was `$`-anchored, so the trailing-slash form never matched and fell through to the catch-all `location / { return 404 }` — the request never reached Django. Both forms are now proxied to the backend.

### 💭 Notes

Root cause was the `$` anchor on the root-level OpenRosa location:

```nginx
location ~ ^/(formList|formUpload|submission|upload)$ {   # before
location ~ ^/(formList|formUpload|submission|upload)/?$ {  # after
```

- Sibling audit: the `/<username>/…` location `^/.+/(formList|submission|xformsManifest|xformsMedia)` is **unanchored**, so it already tolerates a trailing slash — and it also covers `/collector/<token>/submission` (the `.+` matches `collector/<token>`). No separate collector block exists. Only the root-level location had the gap.
- Verified against the running local stack, targeting `kc.kobo.local` (401 is the Django auth challenge when no credentials/body are sent — it confirms the request reached the backend):
  - before: `POST /submission` → `401`, `POST /submission/` → `404` (nginx fallthrough)
  - after:  `POST /submission` → `401`, `POST /submission/` → `401` (both reach backend)
- 🔗 nginx-layer half of DEV-1039; pairs with kpi PR https://github.com/kobotoolbox/kpi/pull/7361, which fixes the Django routing layer (where `/submission/` was misrouted to a CSRF-protected redirect and returned "403 CSRF verification failed"). Both are needed for the full fix on deployments that route through nginx.

### 👀 Preview steps

1. ℹ️ have a deployed project that requires authentication to submit
2. save a valid instance XML as `bet.xml`
3. submit **with** a trailing slash:
   ```
   curl -v --digest --user USER:PASS -X POST -F xml_submission_file=@bet.xml https://kc.kobo.local/submission/
   ```
4. 🔴 [on master] nginx returns `404 Not Found` (request never reaches the backend)
5. 🟢 [on PR] the request reaches the backend; with the kpi fix present, submission is accepted (`201 Created`)
6. 🟢 submit without the trailing slash (`…/submission`) — still works
